### PR TITLE
updates to reflect different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 angelman_viz_keys/
 src/old/
+
+# VS Code
+.vscode/

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,7 +18,7 @@ lxml==5.3.0
 MarkupSafe==2.1.3
 mkl_fft==1.3.11
 mkl_random==1.2.8
-mkl-service==2.4.2
+mkl-service==2.4.0 || mkl-service==2.4.2
 numexpr==2.10.1
 numpy==1.26.4
 pandas==2.2.3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,7 +18,7 @@ lxml==5.3.0
 MarkupSafe==2.1.3
 mkl_fft==1.3.11
 mkl_random==1.2.8
-mkl-service==2.4.0
+mkl-service==2.4.2
 numexpr==2.10.1
 numpy==1.26.4
 pandas==2.2.3


### PR DESCRIPTION
the mkl-service version in requirements.txt is no longer available for install with pip. So I added a backup version. Also updated gitignore to not commit IDE settings