### PR TITLE
fix_fuzz - thefuzz must use my version of the package

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -37,7 +37,7 @@ six==1.16.0
 soupsieve==2.5
 SQLAlchemy==2.0.37
 sshtunnel==0.4.0
-thefuzz==0.22.1
+git+https://github.com/smtodd/thefuzz.git@main#egg=thefuzz
 typing_extensions==4.12.2
 tzdata==2023.3
 urllib3==2.3.0

--- a/src/scraper/scraperASTrial.py
+++ b/src/scraper/scraperASTrial.py
@@ -141,9 +141,9 @@ def as_trials():
             & (as_trials_locs_df1["Lon"] == city[2])
         ]
         
-        #BE CAREFUL, I DON T FIND A METHOD DEDUPE WITH THIS ARG
-        #facilities_dedup = process.dedupe(current_city["Facility"], threshold=70, len_selector="shortest")
-        facilities_dedup = process.dedupe(current_city["Facility"], threshold=70)
+        #This requires the fork at https://github.com/smtodd/thefuzz
+        facilities_dedup = process.dedupe(current_city["Facility"], threshold=70, len_selector="shortest")
+        # facilities_dedup = process.dedupe(current_city["Facility"], threshold=70)
         current_city["Facility_dedupe"] = current_city["Facility"].apply(
             lambda x: process.extractOne(x, facilities_dedup)[0]
         )


### PR DESCRIPTION
I created a version of thefuzz python package that allows dedupe using the shortest string in a group of names. I raised a PR with for the original package, but it has not been reviewed or accepted. This repo requires it to work.