### PR TITLE
fix_fuzz - change thefuzz branch import

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -37,7 +37,7 @@ six==1.16.0
 soupsieve==2.5
 SQLAlchemy==2.0.37
 sshtunnel==0.4.0
-git+https://github.com/smtodd/thefuzz.git@main#egg=thefuzz
+git+https://github.com/smtodd/thefuzz.git@import_221#egg=thefuzz
 typing_extensions==4.12.2
 tzdata==2023.3
 urllib3==2.3.0


### PR DESCRIPTION
Changed the smtodd/thefuzz branch in requirements.txt

The old import had not been working correctly due to edits in thefuzz code.  thefuzz repo has a new branch: import_221 that has the code corrected.  requirements.txt now installs this new branch.